### PR TITLE
fix for non-expansion characters, incorrect map seed bug, and alt toggle map bug

### DIFF
--- a/Structs/Inventory.cs
+++ b/Structs/Inventory.cs
@@ -7,7 +7,9 @@ namespace MapAssist.Structs
     public struct Inventory
     {
         // Used to see if the current player is the correct player
-        // Should not be 0x0 for local player
-        [FieldOffset(0x70)] public IntPtr pUnk1;
+        // Should not be 0 for local player (expansion character)
+        // should not be 1 for local player (non-expansion character)
+        [FieldOffset(0x70)] public int pUnk1Exp;
+        [FieldOffset(0x30)] public int pUnk1NonExp;
     }
 }

--- a/Structs/UiSettings.cs
+++ b/Structs/UiSettings.cs
@@ -24,6 +24,6 @@ namespace MapAssist.Structs
     [StructLayout(LayoutKind.Explicit)]
     unsafe public struct UiSettings
     {
-        [FieldOffset(0x00)] public bool MapShown;
+        [FieldOffset(0x00)] public byte MapShown;
     }
 }

--- a/Types/Difficulty.cs
+++ b/Types/Difficulty.cs
@@ -21,6 +21,7 @@ namespace MapAssist.Types
 {
     public enum Difficulty : ushort
     {
+        None = 99,
         Normal = 0,
         Nightmare = 1,
         Hell = 2

--- a/Types/Offsets.cs
+++ b/Types/Offsets.cs
@@ -23,5 +23,6 @@ namespace MapAssist.Types
     {
         public static int UnitHashTable = 0x20546E0;
         public static int UiSettings = 0x20643A2;
+        public static int ExpansionCharacter = 0x20643B5;
     }
 }


### PR DESCRIPTION
Bandaid fix for getting the wrong map seed/difficulty is just to cache the values instead of grabbing them every time, as sometimes when traveling through a waypoint the data we're reading will become temporarily invalid.

Other fix is to grabbing the player unit, it wasn't working on non expansion characters before, jokerface figured out this fix by checking a byte to see if it's expansion or non-expansion character and checking different offsets from there.

Alt toggle bug where reading map shown as bool is casusing issues.  I think the problem is bool reading multiple bytes instead of 1, could be a cpu or framework/os specific issues IDK